### PR TITLE
Refactor TLS configuration and improve error logging

### DIFF
--- a/app/handler/helper.go
+++ b/app/handler/helper.go
@@ -2,14 +2,13 @@ package handler
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
 	"path"
 	"strings"
 
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"golang.org/x/net/idna"
 )
 
@@ -24,8 +23,8 @@ func checkValue(response http.ResponseWriter, form url.Values, key string) (stri
 }
 
 func handleErrorResponse(response http.ResponseWriter, ip string, statusCode int, errorMessage, printMessage string) {
-	logrus.Infof("Access from IP: %s", ip)
-	logrus.Infof(printMessage)
+	log.Infof("Access from IP: %s", ip)
+	log.Infof(printMessage)
 	response.WriteHeader(statusCode)
 	fmt.Fprintf(response, errorMessage)
 }
@@ -47,7 +46,7 @@ func validateFileAndDomain(ip string, domain string, file string, response http.
 func sanitizedDomain(domain string) string {
 	safe, err := idna.ToASCII(strings.ReplaceAll(domain, "*", "_"))
 	if err != nil {
-		log.Panic(err)
+		log.Error(err)
 	}
 	return safe
 }

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,14 +1,34 @@
 Bind: 0.0.0.0
 Port: 9090
 TimeDiff: 60
-key: 123456
+key: passwd
 Interval: 3600
+
+TlsConfig:
+  Enable: false
+  Domain: test.example.com
+  Bind: 0.0.0.0
+  Port: 9443
 
 CertConfig:
   - CertMode: dns
-    CertDomain: test.example.com
+    CertDomain: test1.example.com
     Provider: cloudflare
     Email: test@test.com
     DNSEnv:
       CLOUDFLARE_EMAIL: YOUR_EMAIL
       CLOUDFLARE_API_KEY: YOUR_API_KEY
+#  - CertMode: http
+#    CertDomain: test2.example.com
+#    Provider: cloudflare
+#    Email: test@test.com
+#    DNSEnv:
+#      CLOUDFLARE_EMAIL: YOUR_EMAIL
+#      CLOUDFLARE_API_KEY: YOUR_API_KEY
+#  - CertMode: tls
+#    CertDomain: test3.example.com
+#    Provider: cloudflare
+#    Email: test@test.com
+#    DNSEnv:
+#      CLOUDFLARE_EMAIL: YOUR_EMAIL
+#      CLOUDFLARE_API_KEY: YOUR_API_KEY

--- a/config/config.go
+++ b/config/config.go
@@ -4,9 +4,12 @@ func DefaultConfig() *Config {
 	return &Config{
 		Bind:     "",
 		Port:     9090,
-		Tls:      false,
-		TlsPort:  9443,
 		Key:      "passwd",
 		TimeDiff: 60,
+		Interval: 3600,
+		TlsConfig: TlsConfig{
+			Enable: false,
+		},
+		CertConfig: nil,
 	}
 }

--- a/config/model.go
+++ b/config/model.go
@@ -3,13 +3,19 @@ package config
 import "github.com/julydate/acmeDeliver/app/mylego"
 
 type Config struct {
-	Bind     string `yaml:"Bind"`
-	Port     int    `yaml:"Port"`
-	Tls      bool   `yaml:"Tls"`
-	TlsPort  int    `yaml:"TlsPort"`
-	Key      string `yaml:"Key"`
-	TimeDiff int64  `yaml:"TimeDiff"`
-	Interval int    `yaml:"Interval"`
+	Bind      string    `yaml:"Bind"`
+	Port      int       `yaml:"Port"`
+	Key       string    `yaml:"Key"`
+	TimeDiff  int64     `yaml:"TimeDiff"`
+	Interval  int       `yaml:"Interval"`
+	TlsConfig TlsConfig `yaml:"TlsConfig"`
 
 	CertConfig []*mylego.CertConfig `yaml:"CertConfig"`
+}
+
+type TlsConfig struct {
+	Enable bool   `yaml:"Enable"`
+	Domain string `yaml:"Domain"`
+	Bind   string `yaml:"Bind"`
+	Port   int    `yaml:"Port"`
 }

--- a/controller/model.go
+++ b/controller/model.go
@@ -6,6 +6,7 @@ import (
 	"github.com/robfig/cron/v3"
 
 	"github.com/julydate/acmeDeliver/app/mylego"
+	"github.com/julydate/acmeDeliver/config"
 )
 
 type Controller struct {
@@ -13,4 +14,5 @@ type Controller struct {
 	myLego    []*mylego.LegoCMD
 	cronJob   *cron.Cron
 	interval  int
+	tlsConfig *config.TlsConfig
 }


### PR DESCRIPTION
Add TLS feat

Reorganized the TLS-related settings into the TlsConfig struct in model.go and controller.go, improving the readability and maintainability of the code. Also, logging in helper.go has been adjusted for consistency, and the log level in the sanitizedDomain function has been downgraded from 'Panic' to 'Error'.